### PR TITLE
Fix for race condition (issue #2)

### DIFF
--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -32,7 +32,7 @@ class TestConnectionPool < MiniTest::Unit::TestCase
     result = threads.map(&:value)
     b = Time.now
     assert_operator((b - a), :>, 0.125)
-    assert_equal([1,2,3].cycle(5).sort, result)
+    assert_equal([1,2,3].cycle(5).sort, result.sort)
   end
 
   def test_timeout


### PR DESCRIPTION
I was able to reproduce the failing test on both 1.9.3 and 1.9.2 using:

rake TESTOPTS="--seed=50855"

After a bit of debugging, it turns out that the test in its current form could yield different results depending on which threads the thread manager decides to run. NetworkConnection#do_something has an explicit sleep, which signals to Ruby that it can execute another thread. Therefore, the order in which the threads execute/complete is not deterministic across test runs - you can see this by printing out when each thread completes in the block passed to ConnectionPool#with_connection.

Sorting the final result to be compared fixes the problem for me!
