### PR TITLE
Added respond_to? extension to wrapper class

### DIFF
--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -87,6 +87,12 @@ class ConnectionPool
     end
     alias_method :with_connection, :with
 
+    def respond_to?(method_symbol, include_private=false)
+      @pool.with do |connection|
+        (connection.methods + self.methods).uniq.include?(method_symbol)
+      end
+    end
+
     def method_missing(name, *args, &block)
       @pool.with do |connection|
         connection.send(name, *args, &block)


### PR DESCRIPTION
When respond_to? is called on a instance of the wrapper class, it would
technically give an incorrect false when a method could just be passed
along to the connection object via method_missing. This resolves that
issue by checking the instance methods of the connection object along
with the instance methods of the wrapper when respond_to? is called.
