### PR TITLE
add license information to the gemspec

### DIFF
--- a/connection_pool.gemspec
+++ b/connection_pool.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+  s.license = "MIT"
 end


### PR DESCRIPTION
this way you can get it when using rubygems.org API
