### PR TITLE
First try to deal with #27

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,13 @@
+1.0.1
+-----
+
+- New `#shutdown` method
+
+    This method accepts a block and calls the block for each
+    connection in the pool. After calling this method, trying to get a
+    connection from the pool raises a `PullShuttingDownError`
+    exception.
+    
 1.0.0
 -----
 

--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -73,6 +73,10 @@ class ConnectionPool
     nil
   end
 
+  def shutdown(&block)
+    @available.shutdown(&block)
+  end
+
   class Wrapper < ::BasicObject
     METHODS = [:with]
 

--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -1,16 +1,25 @@
 require 'thread'
 require 'timeout'
 
+class ConnectionPool::PoolShuttingDownError < RuntimeError
+end
+
 class ConnectionPool::TimedStack
   def initialize(size = 0)
     @que = Array.new(size) { yield }
     @mutex = Mutex.new
     @resource = ConditionVariable.new
+    @shutdown_block = nil
   end
 
   def push(obj)
     @mutex.synchronize do
-      @que.push obj
+      if @shutdown_block
+        @shutdown_block.call(obj)
+      else
+        @que.push obj
+      end
+
       @resource.broadcast
     end
   end
@@ -20,10 +29,25 @@ class ConnectionPool::TimedStack
     deadline = Time.now + timeout
     @mutex.synchronize do
       loop do
+        raise ConnectionPool::PoolShuttingDownError if @shutdown_block
         return @que.pop unless @que.empty?
         to_wait = deadline - Time.now
         raise Timeout::Error, "Waited #{timeout} sec" if to_wait <= 0
         @resource.wait(@mutex, to_wait)
+      end
+    end
+  end
+
+  def shutdown(&block)
+    raise ArgumentError, "shutdown must receive a block" unless block_given?
+
+    @mutex.synchronize do
+      @shutdown_block = block
+      @resource.broadcast
+
+      @que.size.times do
+        conn = @que.pop
+        block.call(conn)
       end
     end
   end

--- a/lib/connection_pool/version.rb
+++ b/lib/connection_pool/version.rb
@@ -1,3 +1,3 @@
 class ConnectionPool
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
There are still a few problems:
1. `shutdown` is not thread safe. If this method gets called while the
   thread holds a connection checked in, it will throw a timeout error.

Also, if `shutdown` is called more than once in different threads, a
deadlock can occur and a timeout error will be raised.
1. After `shutdown` is called, `@available` will be empty, which means
   all `checkin` calls will raise a time out error.

This can be "solved" if we had some kind of check before checking
connections in to assert that the connection was not previously
shutdown, though maybe this should be solved by just not calling
`shutdown` more than once.
