### PR TITLE
Provide access to the pool inside a wrapper (example of features request #32)

### DIFF
--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -79,9 +79,7 @@ class ConnectionPool
   end
 
   class Wrapper < ::BasicObject
-    METHODS = [:with]
-
-    attr_reader :pool
+    METHODS = [:with, :pool_shutdown]
 
     def initialize(options = {}, &block)
       @pool = ::ConnectionPool.new(options, &block)
@@ -91,6 +89,10 @@ class ConnectionPool
       yield @pool.checkout
     ensure
       @pool.checkin
+    end
+
+    def pool_shutdown(&block)
+      @pool.shutdown(&block)
     end
 
     def respond_to?(id, *args)

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -200,8 +200,17 @@ class TestConnectionPool < Minitest::Test
     end
   end
 
-  def test_wrapper_provides_access_to_pool
-    wrapper = ConnectionPool::Wrapper.new(:size => 1) { true }
-    assert_equal ConnectionPool, wrapper.pool.class
+  def test_shutdown_is_executed_for_all_connections_in_wrapped_pool
+    recorders = []
+
+    wrapper = ConnectionPool::Wrapper.new(:size => 3) do
+      Recorder.new.tap { |r| recorders << r }
+    end
+
+    wrapper.pool_shutdown do |recorder|
+      recorder.do_work("shutdown")
+    end
+
+    assert_equal [["shutdown"]] * 3, recorders.map { |r| r.calls }
   end
 end


### PR DESCRIPTION
Example of the desired feature discussed in issue #32.
