### PR TITLE
Added option to force returning new connections

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,10 +1,10 @@
 require 'rubygems'
-require 'minitest/pride'
+require 'minitest'
 require 'minitest/autorun'
 
 require 'connection_pool'
 
-class Minitest::Unit::TestCase
+class Minitest::Test
 
   def async_test(time=0.5)
     q = TimedQueue.new

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -148,6 +148,22 @@ class TestConnectionPool < Minitest::Test
     assert_equal ['inner', 'outer', 'other'], recorder.calls
   end
 
+  def test_nested_checkout_with_new_connection_flag
+    recorders = []
+    pool = ConnectionPool.new(:size => 2, :always_new_connection => true) do
+      Recorder.new.tap { |r| recorders << r }
+    end
+    pool.with do |r_outer|
+      pool.with do |r_inner|
+        r_inner.do_work('inner')
+      end
+
+      r_outer.do_work('outer')
+    end
+
+    assert_equal [['inner'], ['outer']], recorders.map { |r| r.calls }
+  end
+
   def test_shutdown_is_executed_for_all_connections
     recorders = []
 


### PR DESCRIPTION
Here's my attempt. Not sure what was up with the unit tests but I couldn't get "bundle exec rake" or even just "rake" to run minitest without updating the requires and package names.
