### PR TITLE
Connection Pool is per-thread

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,10 +1,10 @@
 require 'rubygems'
-require 'minitest/pride'
+require 'minitest'
 require 'minitest/autorun'
 
 require 'connection_pool'
 
-class Minitest::Unit::TestCase
+class Minitest::Test
 
   def async_test(time=0.5)
     q = TimedQueue.new

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -148,6 +148,22 @@ class TestConnectionPool < Minitest::Test
     assert_equal ['inner', 'outer', 'other'], recorder.calls
   end
 
+  def test_nested_checkout_with_new_connection_flag
+    recorders = []
+    pool = ConnectionPool.new(:size => 2, :always_new_connection => true) do
+      Recorder.new.tap { |r| recorders << r }
+    end
+    pool.with do |r_outer|
+      pool.with do |r_inner|
+        r_inner.do_work('inner')
+      end
+
+      r_outer.do_work('outer')
+    end
+
+    assert_equal [['inner'], ['outer']], recorders.map { |r| r.calls }
+  end
+
   def test_shutdown_is_executed_for_all_connections
     recorders = []
 


### PR DESCRIPTION
I encapsulated the problem I've got into this gist:

http://gist.github.com/walkeriniraq/6237127

Basically, a redis connection is stateful, in that it "remembers" whether or not it's in a pipeline call. When it's in a pipeline, the return values are promises instead of actual database values. Since the connection pool shares a single connection across the entire thread, it can lead to some surprising behavior.

It doesn't seem like SQL connections have this problem as the connection itself is not stateful - i.e. starting a transaction on a SQL connection doesn't stop the connection from making other calls.

I've "solved" the problem in my own branch by returning a new connection for every request to the connection pool, but that breaks the current "nested" checkout tests (as it does exactly the opposite of what they're supposed to test). 

The only other thing I can think of is to add an option to the initializer. I'm open to better ideas though. 
