### PR TITLE
Added the "reset" method call, to set a connection to a defined state

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ end
 Once you've ported your entire system to use `with`, you can simply
 remove ::Wrapper and use a simple, fast ConnectionPool.
 
+ReSetting a connection
+--------------
+
+Redis and other connections, will often have a connection parameter changed.  
+Use `reset` to insure that the connection is in a pre-defined state 
+and does not have artifacts from the last usage.
+
+```ruby
+$redis = ConnectionPool::Wrapper.new(:size => 5, :timeout => 3) { Redis.connect }
+$redis.reset do | redis | 
+  redis.select 0
+end
+```
+
 Author
 --------------
 

--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -47,6 +47,11 @@ class ConnectionPool
 
     @available = TimedStack.new(@size, &block)
     @key = :"current-#{@available.object_id}"
+    @reset = nil
+  end
+
+  def reset(&block) 
+    @reset = block
   end
 
   def with(options = {})
@@ -69,6 +74,10 @@ class ConnectionPool
     end
 
     stack.push conn
+
+    # this code will restore a connection to preset defaults
+    @reset.call(conn) if @reset
+
     conn
   end
 

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -4,8 +4,12 @@ require 'helper'
 class TestConnectionPool < Minitest::Test
 
   class NetworkConnection
+
+    attr_accessor :state
+
     def initialize
       @x = 0
+      @state = :clean
     end
 
     def do_something
@@ -75,6 +79,21 @@ class TestConnectionPool < Minitest::Test
     sleep 0.05
     pool.with do |conn|
       refute_nil conn
+    end
+  end
+
+  def test_re_initialize
+    pool = ConnectionPool.new(:timeout => 0.05, :size => 1) { NetworkConnection.new }
+    pool.reset do | connection |
+      connection.state = :clean
+    end
+
+    pool.with do | connection | 
+      connection.state = :dirty
+    end
+
+    pool.with do | connection | 
+      assert :clean, connection.state
     end
   end
   


### PR DESCRIPTION
Greetings,

I use redis and I often set various databases for different purposes.  I have modified your code to include a `reset` method call that will accept a block of code, which will run on checkout, and reset the connection.

Test code is included and passes.

My current usage is to use this for setting the redis database to the default '0' database.

Other usages, would be various MySQL settings (set names utf8, auto_commit, etc)

Please let me know if you have any questions!

Thank you!

-daniel
