### PR TITLE
Add query method to avoid method_missing for most SQL DB connections

### DIFF
--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -86,7 +86,7 @@ class ConnectionPool
   end
 
   class Wrapper < ::BasicObject
-    METHODS = [:with, :pool_shutdown]
+    METHODS = [:with, :pool_shutdown, :query]
 
     def initialize(options = {}, &block)
       @pool = ::ConnectionPool.new(options, &block)
@@ -96,6 +96,12 @@ class ConnectionPool
       yield @pool.checkout
     ensure
       @pool.checkin
+    end
+
+    def query(*args)
+      with do |conn|
+        conn.query *args
+      end
     end
 
     def pool_shutdown(&block)


### PR DESCRIPTION
I've come adding this for performance, as almost every use I make of this pool is for MySQL connections, and almost every call I made on them is to `query`. 

Maybe you could merge it as it does not really bother much the rest of the code. Maybe not. Your choice!

Thanks anyway. 
