### PR TITLE
Test ConnectionPool::TimedStack

### DIFF
--- a/test/test_connection_pool_timed_stack.rb
+++ b/test/test_connection_pool_timed_stack.rb
@@ -55,7 +55,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_pop_shutdown
-    @stack.shutdown do end
+    @stack.shutdown { }
 
     assert_raises ConnectionPool::PoolShuttingDownError do
       @stack.pop


### PR DESCRIPTION
This adds test for TimedStack.

I want to use connection_pool in net-http-persistent.  To support this I need to be able to create different types of connections (by URI) and track them (because that's what Net::HTTP's API requires).

This might involve changes to TimedStack, it was untested, so here you go.
