### PR TITLE
Improve connection pool wrapper tests

### DIFF
--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -260,4 +260,18 @@ class TestConnectionPool < Minitest::Test
     assert_respond_to wrapper, :fast
     refute_respond_to wrapper, :"nonexistent method"
   end
+
+  def test_wrapper_with
+    wrapper = ConnectionPool::Wrapper.new(:size => 1) { Object.new }
+
+    wrapper.with do
+      assert_raises Timeout::Error do
+        Thread.new do
+          wrapper.with { flunk 'connection checked out :(' }
+        end.join
+      end
+    end
+
+    assert Thread.new { wrapper.with { } }.join
+  end
 end


### PR DESCRIPTION
This completes coverage of the methods in ConnectionPool::Wrapper.
