### PR TITLE
Move docs for TimedStack to just above the TimedStack class definition

### DIFF
--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -4,7 +4,14 @@ require 'timeout'
 ##
 # Raised when you attempt to retrieve a connection from a pool that has been
 # shut down.
-#
+
+class ConnectionPool::PoolShuttingDownError < RuntimeError; end
+
+##
+# The TimedStack manages a pool of homogeneous connections (or any resource
+# you wish to manage).  Connections are created lazily up to a given maximum
+# number.
+
 # Examples:
 #
 #    ts = TimedStack.new(1) { MyConnection.new }
@@ -18,13 +25,6 @@ require 'timeout'
 #    conn = ts.pop
 #    ts.pop timeout: 5
 #    #=> raises Timeout::Error after 5 seconds
-
-class ConnectionPool::PoolShuttingDownError < RuntimeError; end
-
-##
-# The TimedStack manages a pool of homogeneous connections (or any resource
-# you wish to manage).  Connections are created lazily up to a given maximum
-# number.
 
 class ConnectionPool::TimedStack
 


### PR DESCRIPTION
I was reading through the source and thought I was reading about when the `PoolShuttingDownError` gets raised but was actually reading about how to use the `TimedStack` class. I think reorganizing the comments like this makes more sense.

The diff seems to have come out a little bit weird, what I did was move the `example` comments to just above the `TimedStack` class definiton.

Here's a screenshot of what the file looks like after moving the comments:
![](http://i.imgur.com/EdNx4UH.png)
