### PR TITLE
Return value from ConnectionPool#with

### DIFF
--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -55,7 +55,7 @@ class ConnectionPool
   def with(options = {})
     conn = checkout(options)
     begin
-      yield conn
+      return yield conn
     ensure
       checkin
     end
@@ -101,7 +101,7 @@ class ConnectionPool
     def with
       conn = @pool.checkout
       begin
-        yield conn
+        return yield conn
       ensure
         @pool.checkin
       end


### PR DESCRIPTION
It's often ~~hard~~ ugly to use ConnectionPool's concurrency in a performant way (read: without the wrapper). I modified the `ConnectionPool#with` method so that it returns whatever its block returns.

```
def exec(sql)
  res = nil
  @pool.with { |pg| res = pg.exec sql }
  res
end
```

Look more like this

```
def exec(sql)
  @pool.with { |pg| pg.exec sql }
end
```
