### PR TITLE
define method when method missing

### DIFF
--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -399,6 +399,14 @@ class TestConnectionPool < Minitest::Test
     refute_respond_to wrapper, :"nonexistent method"
   end
 
+  def test_wrapper_method_missing
+    wrapper = ConnectionPool::Wrapper.new { NetworkConnection.new }
+
+    assert_raises NoMethodError do
+      wrapper.an_undefiend_method
+    end
+  end
+
   def test_wrapper_with
     wrapper = ConnectionPool::Wrapper.new(:timeout => 0, :size => 1) { Object.new }
 


### PR DESCRIPTION
We use connection_pool in our server.

``` ruby
$redis = ConnectionPool::Wrapper.new(size: 5, timeout: 3) { Redis.connect }
$redis.sadd('foo', 1)
```

In fact, the method named `sadd` is one of Redis.connect`s methods which is delegated by ConnectionPool::Wrappe#method_missing.

It's more efficient to define the method when method missing.
