### PR TITLE
Travis docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
+sudo: false
 language: ruby
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 sudo: false
+cache: bundler
 language: ruby
 rvm:
   - 1.9.3


### PR DESCRIPTION
Uses Travis' container based infrastructure for quicker builds.

Also caches bundles between builds for even quicker builds. 