### PR TITLE
Extend dirty checking to the stack

### DIFF
--- a/test/test_connection_pool_timed_stack.rb
+++ b/test/test_connection_pool_timed_stack.rb
@@ -127,4 +127,3 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
 end
-


### PR DESCRIPTION
Thought this would take a bit more originally, but realized we can just change how we store connections and use a hash and it's pretty easy. Builds on what @tamird did

This is the least compatibility breaking way of doing it. If you wanted to extend this so people can use `checkout` and `checkin` and get the same kind of dirty tracking automatically, you could make `checkout` and option to return the entry so they can set the flags themselves. In which case, encapsulating it with a class would make it a little cleaner.