### PR TITLE
Don’t pass disconnect through redis-namespace connection. Closes resque/...

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+2.1.3
+------
+- redis-namespace connections which respond to `redis` disconnect by invoking
+  the method on the underlying connection.
+
 2.1.2
 ------
 

--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -129,6 +129,8 @@ class ConnectionPool::TimedStack
         # try to shut down the connection before throwing it away
         if obj.respond_to?(:close) # Dalli::Client
           obj.close rescue nil
+        elsif obj.respond_to?(:redis) # redis-namespace
+          obj.redis.disconnect! rescue nil
         elsif obj.respond_to?(:disconnect!) # Redis
           obj.disconnect! rescue nil
         end


### PR DESCRIPTION
...redis-namespace#98 and closes mperham/sidekiq#2213.

Not super pretty, but does the trick.