### PR TITLE
Do not increment `@created` object counter in `TimedStack` before object creation actually succeeds

### DIFF
--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -188,8 +188,9 @@ class ConnectionPool::TimedStack
 
   def try_create(options = nil)
     unless @created == @max
+      object = @create_block.call
       @created += 1
-      @create_block.call
+      object
     end
   end
 end

--- a/test/test_connection_pool_timed_stack.rb
+++ b/test/test_connection_pool_timed_stack.rb
@@ -34,6 +34,25 @@ class TestConnectionPoolTimedStack < Minitest::Test
     assert_equal 1, stack.length
   end
 
+  def test_object_creation_fails
+    stack = ConnectionPool::TimedStack.new(2) { raise 'failure' }
+
+    begin
+      stack.pop
+    rescue => error
+      assert_equal 'failure', error.message
+    end
+
+    begin
+      stack.pop
+    rescue => error
+      assert_equal 'failure', error.message
+    end
+
+    refute_empty stack
+    assert_equal 2, stack.length
+  end
+
   def test_pop
     object = Object.new
     @stack.push object


### PR DESCRIPTION
In the case that object creation throws an exception, the `@created` counter was still being incremented, effectively taking up a slot in the pool forever.