### PR TITLE
Non-local return forces disconnect

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,12 @@
+connection\_pool changelog
+---------------------------
+
+2.1.4
+------
+
+- Rollback `Timeout` handling introduced in 2.1.1 and 2.1.2.  It seems
+  impossible to safely work around the issue. [#75]
+
 2.1.3
 ------
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,11 +1,12 @@
 connection\_pool changelog
 ---------------------------
 
-2.1.4
+2.2.0
 ------
 
 - Rollback `Timeout` handling introduced in 2.1.1 and 2.1.2.  It seems
-  impossible to safely work around the issue. [#75]
+  impossible to safely work around the issue. Please never, ever use
+  `Timeout.timeout` in your code or you will see rare but mysterious bugs. [#75]
 
 2.1.3
 ------

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ MongoDB has its own connection pool.  ActiveRecord has its own connection pool.
 This is a generic connection pool that can be used with anything, e.g. Redis,
 Dalli and other Ruby network clients.
 
+**WARNING**: Don't ever use `Timeout.timeout` in your Ruby code or you will see
+occasional silent corruption and mysterious errors.  The Timeout API is unsafe
+and cannot be used correctly, ever.  Use proper socket timeout options as
+exposed by Net::HTTP, Redis, Dalli, etc.
+
 
 Usage
 -----

--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -117,22 +117,6 @@ class ConnectionPool::TimedStack
     @max - @created + @que.length
   end
 
-  ##
-  # Indicates that a connection isn't coming back, allowing a new one to be
-  # created to replace it.
-
-  def discard!(obj)
-    @mutex.synchronize do
-      if @shutdown_block
-        @shutdown_block.call(obj)
-      else
-        @created -= 1
-      end
-
-      @resource.broadcast
-    end
-  end
-
   private
 
   ##

--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -126,12 +126,6 @@ class ConnectionPool::TimedStack
       if @shutdown_block
         @shutdown_block.call(obj)
       else
-        # try to shut down the connection before throwing it away
-        if obj.respond_to?(:close) # Dalli::Client
-          obj.close
-        elsif obj.respond_to?(:disconnect!) # Redis
-          obj.disconnect!
-        end
         @created -= 1
       end
 

--- a/lib/connection_pool/version.rb
+++ b/lib/connection_pool/version.rb
@@ -1,3 +1,3 @@
 class ConnectionPool
-  VERSION = "2.1.3"
+  VERSION = "2.1.4"
 end

--- a/lib/connection_pool/version.rb
+++ b/lib/connection_pool/version.rb
@@ -1,3 +1,3 @@
 class ConnectionPool
-  VERSION = "2.1.4"
+  VERSION = "2.2.0"
 end

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -124,6 +124,8 @@ class TestConnectionPool < Minitest::Test
   end
 
   def test_checkout_ignores_timeout
+    skip("Thread.handle_interrupt not available") unless Thread.respond_to?(:handle_interrupt)
+
     pool = ConnectionPool.new(:timeout => 0, :size => 1) { Object.new }
     def pool.checkout(options)
       sleep 0.015

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -109,6 +109,21 @@ class TestConnectionPool < Minitest::Test
     assert Thread.new { pool.checkout }.join
   end
 
+  def test_with_timeout
+    pool = ConnectionPool.new(:timeout => 0, :size => 1) { Object.new }
+
+    assert_raises Timeout::Error do
+      Timeout.timeout(0.01) do
+        pool.with do |obj|
+          assert_equal 0, pool.instance_variable_get(:@available).instance_variable_get(:@que).size
+          sleep 0.011
+        end
+      end
+    end
+
+    assert_equal 1, pool.instance_variable_get(:@available).instance_variable_get(:@que).size
+  end
+
   def test_explicit_return
     pool = ConnectionPool.new(:timeout => 0, :size => 1) do
       mock = Minitest::Mock.new


### PR DESCRIPTION
The changes in #67 have resulted in unnecessary connection discards when using an explicit return:

```ruby
pool = ConnectionPool.new
pool.with do |conn|
  return true
end
```

The explicit return means that the `success = true` line within `with` is not executed.