### PR TITLE
Redis-rb doesn't have a close method

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ will work.
 
 ```ruby
 cp = ConnectionPool.new { Redis.new }
-cp.shutdown { |conn| conn.close }
+cp.shutdown { |conn| conn.quit }
 ```
 
 Shutting down a connection pool will block until all connections are checked in and closed.


### PR DESCRIPTION
Here's the quit method in [redis-rb](https://github.com/redis/redis-rb/blob/master/lib/redis.rb#L103-L115).