### PR TITLE
Monotonic clock for more accurate timeouts.

### DIFF
--- a/lib/connection_pool/monotonic_time.rb
+++ b/lib/connection_pool/monotonic_time.rb
@@ -1,0 +1,66 @@
+# Global monotonic clock from Concurrent Ruby 1.0.
+# Copyright (c) Jerry D'Antonio -- released under the MIT license.
+# Slightly modified; used with permission.
+# https://github.com/ruby-concurrency/concurrent-ruby
+
+require 'thread'
+
+class ConnectionPool
+
+  class_definition = Class.new do
+
+    if defined?(Process::CLOCK_MONOTONIC)
+
+      # @!visibility private
+      def get_time
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+    elsif defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
+
+      # @!visibility private
+      def get_time
+        java.lang.System.nanoTime() / 1_000_000_000.0
+      end
+
+    else
+
+      # @!visibility private
+      def initialize
+        @mutex = Mutex.new
+        @last_time = Time.now.to_f
+      end
+
+      # @!visibility private
+      def get_time
+        @mutex.synchronize do
+          now = Time.now.to_f
+          if @last_time < now
+            @last_time = now
+          else # clock has moved back in time
+            @last_time += 0.000_001
+          end
+        end
+      end
+    end
+  end
+
+  ##
+  # Clock that cannot be set and represents monotonic time since
+  # some unspecified starting point.
+  #
+  # @!visibility private
+  GLOBAL_MONOTONIC_CLOCK = class_definition.new
+  private_constant :GLOBAL_MONOTONIC_CLOCK
+
+  class << self
+    ##
+    # Returns the current time a tracked by the application monotonic clock.
+    #
+    # @return [Float] The current monotonic time when `since` not given else
+    #   the elapsed monotonic time between `since` and the current time
+    def monotonic_time
+      GLOBAL_MONOTONIC_CLOCK.get_time
+    end
+  end
+end


### PR DESCRIPTION
Timers using the system clock are inherently buggy. This PR copies the monotonic clock from concurrent-ruby into this gem and uses it for the timers in `TimedStack`. This optimization in concurrent-ruby was [originally suggested by Aaron Patterson](https://github.com/ruby-concurrency/concurrent-ruby/pull/253).

The system clock is bad for timers because it regularly changes: NTP synchronization, VM adjustment, manual change, etc. Monotonic clocks exist specifically for timers and are generally controlled directly by the processor. Modern operating systems all have a monotonic clock, but older versions of Ruby do not provide access to it.

The clock class in this PR detects the availability of a monotonic clock. On Ruby versions where a monotonic clock is available (MRI 2.1 and newer, all JRuby) it is used. One other systems (MRI 2.0.0 and earlier, Rubinius) a pure-Ruby monotonic clock is used. This application-level clock follows the most common algorithm.

In all cases this clock is at least as accurate as the existing method (using the system clock). In many cases this clock is more accurate.

NOTE: I chose to copy the clock from c-r rather than add a runtime dependency. This gem is very elegant, lightweight, and currently has no runtime dependencies. Adding all of c-r just for the clock felt inappropriate.