### PR TITLE
Create wrapper with existing pool

### DIFF
--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -124,7 +124,7 @@ end
     METHODS = [:with, :pool_shutdown]
 
     def initialize(options = {}, &block)
-      @pool = ::ConnectionPool.new(options, &block)
+      @pool = options.fetch(:pool) { ::ConnectionPool.new(options, &block) }
     end
 
     def with(&block)

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -488,4 +488,14 @@ class TestConnectionPool < Minitest::Test
     assert_equal "eval'ed 1", wrapper.eval(1)
   end
 
+  def test_wrapper_with_connection_pool
+    recorder = Recorder.new
+    pool = ConnectionPool.new(size: 1) { recorder }
+    wrapper = ConnectionPool::Wrapper.new(pool: pool)
+
+    pool.with { |r| r.do_work('with') }
+    wrapper.do_work('wrapped')
+
+    assert_equal ['with', 'wrapped'], recorder.calls
+  end
 end


### PR DESCRIPTION
I have a Rails app that is mostly using Redis for Sidekiq, but has a couple of other calls to Redis. I'd like to be able to use the same connection pool for these calls and Sidekiq, which would let me have only one Redis connection per thread.

e.g. with a setup like this
```ruby
# initializers
threads = 5
$redis_pool = ConnectionPool.new(size: threads)
$redis = ConnectionPool::Wrapper.new(pool: $redis_pool)
Sidekiq.configure_client do |config|
  config.redis = $redis_pool
end
```

I could have this code in a thread and only have one Redis connection checked in at the end.
```ruby
# app code
$redis.ping
MyWorker.perform_async(1, 2, 3)
```

Am I missing something? Could this be useful for ConnectionPool?