### PR TITLE
add info about stats to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ Shutting down a connection pool will block until all connections are checked in 
 **Note that shutting down is completely optional**; Ruby's garbage collector will reclaim
 unreferenced pools under normal circumstances.
 
+## Current state
+
+There are several methods that returns information about pool.
+
+1. `#size` - current size of the pool
+
+2. `#available` - number of currently available connections
+
+```ruby
+cp = ConnectionPool.new(size: 10) { Redis.new }
+cp.size # => 10
+cp.available # => 10
+
+cp.with do |conn|
+  cp.size # => 10
+  cp.available # => 9
+end
+```
 
 Notes
 -----

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -122,12 +122,12 @@ class TestConnectionPool < Minitest::Test
     assert_raises Timeout::Error do
       Timeout.timeout(0.01) do
         pool.with do |obj|
-          assert_equal 0, pool.instance_variable_get(:@available).instance_variable_get(:@que).size
+          assert_equal 0, pool.available
           sleep 0.015
         end
       end
     end
-    assert_equal 1, pool.instance_variable_get(:@available).instance_variable_get(:@que).size
+    assert_equal 1, pool.available
   end
 
   def test_checkout_ignores_timeout
@@ -153,7 +153,7 @@ class TestConnectionPool < Minitest::Test
       end
     end
     assert did_something
-    assert_equal 1, pool.instance_variable_get(:@available).instance_variable_get(:@que).size
+    assert_equal 1, pool.available
   end
 
   def test_explicit_return


### PR DESCRIPTION
This issue https://github.com/mperham/connection_pool/issues/94 is already closed by https://github.com/mperham/connection_pool/pull/97 PR. 
But it is unclear to users that they have already opportunity to get stats without accessing instance variables (last comment https://github.com/mperham/connection_pool/issues/94#issuecomment-371143167 is relatively fresh).

This PR updates README and changes some test cases to use public methods instead of internal instance variables. 