### PR TITLE
Ensure pool size is integer

### DIFF
--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -46,7 +46,7 @@ class ConnectionPool
 
     options = DEFAULTS.merge(options)
 
-    @size = options.fetch(:size)
+    @size = options.fetch(:size).to_i
     @timeout = options.fetch(:timeout)
 
     @available = TimedStack.new(@size, &block)

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -513,4 +513,13 @@ class TestConnectionPool < Minitest::Test
       assert_equal(1, pool.available)
     end
   end
+
+  def test_stats_with_string_size
+    pool = ConnectionPool.new(size: '2') { NetworkConnection.new }
+
+    pool.with do
+      assert_equal(2, pool.size)
+      assert_equal(1, pool.available)
+    end
+  end
 end


### PR DESCRIPTION
We ran in to an issue with using a string value as the connection pool size and it not behaving as we expected or throw an error. The issue is that we have an environment variable dictate the connection pool size, which is a string. After inspection we realized new connections were being returned each time and no obvious error or warning that our setting was incorrect. 

To reproduce,

```ruby
pool = ConnectionPool.new(size: '8') do
  Object.new
end

9.times { Thread.new { puts pool.checkout.object_id } }
# will output 9 different object_ids and thus unique pusher clients
```

The expected behavior would be a `Timeout::Error` because all the connections _should_ be checked out. You can also use `ConnectionPool#available` which will throw an error.

I'm not a fan of introducing code that could break existing implementations, but it seems to me that other people might be using connection pooling, and similarly passing in a string value (perhaps also using environment variables as we do). I think this is a nice noninvasive solution to enforcing an integer size for the connection pool object.