### PR TITLE
CI: Drop unused sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-sudo: false
 cache: bundler
 language: ruby
 rvm:


### PR DESCRIPTION
  - Read more about the removal here https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration