### PR TITLE
CI: Use 2.6.4, 2.5.6, 2.4.7, jruby-9.2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: ruby
 rvm:
   - 2.3.8
   - 2.4.6
-  - 2.5.5
-  - 2.6.3
-  - jruby-9.2.7.0
+  - 2.5.6
+  - 2.6.4
+  - jruby-9.2.8.0
+jdk:
+  - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 language: ruby
 rvm:
   - 2.3.8
-  - 2.4.6
+  - 2.4.7
   - 2.5.6
   - 2.6.4
   - jruby-9.2.8.0


### PR DESCRIPTION
This updates the CI matrix to use the latest releases.

~(I had some issues getting 2.4.7 to install via `rvm`, but that release _only_ contains the RDoc upgrade, no backports. 2.5, 2.6 got some new stuff.)~

(This _also_ sets the used JDK to openjdk8, in order not to have to set `--add-opens`.)