### PR TITLE
CI: Use 2.6, 2.5, 2.4, jruby-9.2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@
 cache: bundler
 language: ruby
 rvm:
-  - 2.3.8
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
-  - jruby-9.2.7.0
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - jruby-9.2.8.0
+jdk:
+  - openjdk8


### PR DESCRIPTION
This PR changes the CI matrix to a less-churn style which is auto-updated as and when the `rvm` installation in Travis gets updated.