### PR TITLE
Removed explicitly declaration of thread library

### DIFF
--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -1,4 +1,3 @@
-require 'thread'
 require 'timeout'
 
 ##


### PR DESCRIPTION
`thread` library was removed from Ruby 1.9. 