### PR TITLE
Adding an optional healthcheck feature

### DIFF
--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -32,7 +32,11 @@ require_relative 'connection_pool/timed_stack'
 # - :timeout - amount of time to wait for a connection if none currently available, defaults to 5 seconds
 #
 class ConnectionPool
-  DEFAULTS = {size: 5, timeout: 5}
+  DEFAULTS = {
+    size: 5,
+    timeout: 5,
+    healthcheck: ->(_) { true }
+  }
 
   class Error < RuntimeError
   end
@@ -48,8 +52,9 @@ class ConnectionPool
 
     @size = Integer(options.fetch(:size))
     @timeout = options.fetch(:timeout)
+    @healthcheck = options.fetch(:healthcheck)
 
-    @available = TimedStack.new(@size, &block)
+    @available = TimedStack.new(@size, @healthcheck, &block)
     @key = :"pool-#{@available.object_id}"
     @key_count = :"pool-#{@available.object_id}-count"
   end


### PR DESCRIPTION
Adds an optional `:healthcheck` option to `ConnectionPool` that accepts a Lambda. Defaults to always returning true (thus basically is disabled by default) but allows executing arbitrary code (within the safety of the mutex) to determine if the object is healthy on demand just before returning the pool member.

I'll submit another commit tomorrow to update the documentation if this is acceptable.

This _might_ address #125 depending on the use case.