### PR TITLE
Add reaper for unused connections

### DIFF
--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -92,6 +92,12 @@ class ConnectionPool
     nil
   end
 
+  # Removes a connection from the pool and makes the space available again
+  # connection may not currently be checked out of the queue.
+  def remove_connection(conn)
+    @available.remove_connection(conn)
+  end
+
   def shutdown(&block)
     @available.shutdown(&block)
   end

--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -117,6 +117,12 @@ class ConnectionPool::TimedStack
     @max - @created + @que.length
   end
 
+  def remove_connection(conn)
+    @mutex.synchronize do
+      @created -= 1 if @que.delete(conn)
+    end
+  end
+
   private
 
   def current_time

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -554,4 +554,20 @@ class TestConnectionPool < Minitest::Test
       assert_equal(1, pool.available)
     end
   end
+
+  def test_removing_and_replacing_connections
+    created = 0
+    pool = ConnectionPool.new(timeout:0, size: 1) do
+      created += 1
+      NetworkConnection.new
+    end
+
+    conn = pool.checkout
+    pool.checkin
+
+    pool.remove_connection(conn)
+    pool.with{  }
+
+    assert_equal created, 2
+  end
 end


### PR DESCRIPTION
Here is my first proposal for a connection reaper.

Test are added at the connection level, since test of the reaper class itself would require enough mocking to make it more fragile.

There is still race condition, where a connection is checked out during a reaping. The connection will be removed and then closed, odds are the consumer will encounter a runtime error at that point.

The only way to fix this would be to share the mutex, either by passing it into the reaper or bringing the reaping logic into the Connection Pool class.

I'm currently letting this soak in our test env at work to ensure it works as expected.