### PR TITLE
CI: Run latest JRuby release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
-  - jruby-9.2.8.0
+  - jruby-9.2.11.1
 jdk:
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ rvm:
   - 2.7
   - jruby
 jdk:
-  - openjdk8
+  - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
-  - jruby-9.2.11.1
+  - jruby
 jdk:
   - openjdk8


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.11.1**.

[JRuby 9.2.11.1 release blog post](https://www.jruby.org/2020/03/25/jruby-9-2-11-1.html)

**Update**: I changed the configuration not to point to a release, but to an `rvm` alias.

`rvm` responded with this:

```
$ rvm use jruby --install --binary --fuzzy
curl: (22) The requested URL returned error: 404 Not Found
Required jruby-head is not installed - installing.
```