### PR TITLE
README: Use API Redis.new in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can use `ConnectionPool::Wrapper` to wrap a single global connection,
 making it easier to migrate existing connection code over time:
 
 ``` ruby
-$redis = ConnectionPool::Wrapper.new(size: 5, timeout: 3) { Redis.connect }
+$redis = ConnectionPool::Wrapper.new(size: 5, timeout: 3) { Redis.new }
 $redis.sadd('foo', 1)
 $redis.smembers('foo')
 ```


### PR DESCRIPTION
This PR updates a README example to the code which is found in the library.

## Why this change?

Redis-rb 4.x dropped the `Redis.connect` method.

I looked around my dependencies for usages, and hit this code on text-searching in my local files.