### PR TITLE
Change comments to use ConnectionPool::TimeoutError

### DIFF
--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -15,7 +15,7 @@
 #
 #    conn = ts.pop
 #    ts.pop timeout: 5
-#    #=> raises Timeout::Error after 5 seconds
+#    #=> raises ConnectionPool::TimeoutError after 5 seconds
 
 class ConnectionPool::TimedStack
   attr_reader :max
@@ -54,7 +54,7 @@ class ConnectionPool::TimedStack
   ##
   # Retrieves a connection from the stack.  If a connection is available it is
   # immediately returned.  If no connection is available within the given
-  # timeout a Timeout::Error is raised.
+  # timeout a ConnectionPool::TimeoutError is raised.
   #
   # +:timeout+ is the only checked entry in +options+ and is preferred over
   # the +timeout+ argument (which will be removed in a future release).  Other


### PR DESCRIPTION
With the introduction of `ConnectionPool::TimeoutError` in https://github.com/mperham/connection_pool/commit/dd5dac56607a146aa29ec4ef557c42726541a2fa the comments have not been changed.

Now they reflect what is being thrown.

PS: I did not search the whole codebase, only saw the mismatch in this file.