### PR TITLE
Not support unsupported ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@
 cache: bundler
 language: ruby
 rvm:
-  - 2.3
-  - 2.4
   - 2.5
   - 2.6
   - 2.7


### PR DESCRIPTION
2.3 is unsupported since > 1 year: https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/
2.4 support ended in April 2010: https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/

This might be a bigger breaking change, so I guess more thought and planing should go in. But I just wanted to start this topic, as I also see that current Travis builds are failing.

They are failing because of rubocop not supporting ruby 2.3, and that lead me to check the ruby supported versions ;)