### PR TITLE
Add required_ruby_version to the Gemspec

### DIFF
--- a/connection_pool.gemspec
+++ b/connection_pool.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler"
   s.add_development_dependency "minitest", ">= 5.0.0"
   s.add_development_dependency "rake"
+  s.required_ruby_version = ">= 2.2.0"
 end


### PR DESCRIPTION
Follow-up to https://github.com/mperham/connection_pool/issues/133

The ruby version check is permissive on purpose, i.e. it will also allow the gem install for Ruby version 3.x. as I am not aware of any problems this gem would have with Ruby 3.x and it will allow people using Ruby 3 beta versions to use this gem.