### PR TITLE
Remove `@key_count` from the thread when returning the connection to …

### DIFF
--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -83,6 +83,7 @@ class ConnectionPool
       if ::Thread.current[@key_count] == 1
         @available.push(::Thread.current[@key])
         ::Thread.current[@key] = nil
+        ::Thread.current[@key_count] = nil
       else
         ::Thread.current[@key_count] -= 1
       end


### PR DESCRIPTION
When checking in the last reference to a connection from a specific thread, the `@key_count` variable is left lingering on the thread with a value of `1`.

It doesn't cause a bug, but it pollutes the namespace with data that is unused and incorrect.

cc/ @audthecodewitch