### PR TITLE
RFC: Implement `ConnectionPool#then`

### DIFF
--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -67,6 +67,7 @@ class ConnectionPool
       end
     end
   end
+  alias then with
 
   def checkout(options = {})
     if ::Thread.current[@key]

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -117,6 +117,12 @@ class TestConnectionPool < Minitest::Test
     assert Thread.new { pool.checkout }.join
   end
 
+  def test_then
+    pool = ConnectionPool.new { Object.new }
+
+    assert_equal pool.method(:then), pool.method(:with)
+  end
+
   def test_with_timeout
     pool = ConnectionPool.new(timeout: 0, size: 1) { Object.new }
 


### PR DESCRIPTION
### What?

In Ruby 2.5, [Object#then](https://apidock.com/ruby/v2_6_3/Object/then) was added as a standard way to "yield self" to the caller. This convention is useful since it allows for library maintainers to abstract access to a value.

For example, [Concurrent#Promise](https://ruby-concurrency.github.io/concurrent-ruby/1.1.4/Concurrent/Promise.html) implements `.then` in a way which allow access to a concurrently resolved value:

```ruby
Concurrent::Promise.execute { :foo }.then { |val| puts val } #=> :foo 

# provides the same value as

:foo.then { |val| puts val } #=> :foo 
```

### The Problem

When using `connection-pool` in the wild, on multiple occasions I have been unable to directly pass a `ConnectionPool` wrapped Redis to a library. Most recently, we [can't use a `ConnectionPool` Redis in `rack-mini-profiler`](https://github.com/MiniProfiler/rack-mini-profiler/blob/19348a0efc39a5a383b588787fa06589c1b3eff1/lib/mini_profiler/storage/redis_store.rb#L21) since it, rightfully, assumes the Redis connection is an actual `Redis::Client`.

Unfortunately, currently library maintainers like `rack-mini-profiler` have no easy way to support **both** raw `Redis::Client` and a `ConnectionPool` Redis. In order to be compatible with both, they would have to specifically check if the object responds to `.with`, and add conditional codepaths. Some library actually do this, which is nice! But overall, it's painful to have to support two codepaths.

### Proposed Solution

By adding `.then`, gems would have a way to support both raw Redis and CP Redis **using the same codepath**, no conditionals. Offering this API offers an easily adoptable and ergonomic interface for Ruby 2.5+:

```ruby
# only compatible with Redis::Client, and ConnectionPool::Wrapper
redis.set 'foo' 'bar'

# compatible with Redis::Client, and ConnectionPool Redis 🎉
redis.then { |r| r.set 'foo' 'bar' }
```


Thoughts?
