### PR TITLE
Define methods for wrapper in method_missing to solve performance issues

### DIFF
--- a/lib/connection_pool/wrapper.rb
+++ b/lib/connection_pool/wrapper.rb
@@ -33,6 +33,15 @@ class ConnectionPool
     # rubocop:disable Style/MethodMissingSuper
     # rubocop:disable Style/MissingRespondToMissing
     def method_missing(name, *args, &block)
+      eigen_class = class << self; self; end
+      eigen_class.class_eval <<-RUBY
+        def #{name}(*args, &block)
+          with do |connection|
+            connection.#{name}(*args, &block)
+          end
+        end
+      RUBY
+
       with do |connection|
         connection.send(name, *args, &block)
       end


### PR DESCRIPTION
To allow usage of wrapper without performance hit each time new call is hitting method_missing class_eval used to define proxy method in wrapper itself. Cost of this feature is that initial call will take a little longer but each subsequent call should be much faster and negate performance cost of using wrapper. 

In case feature itself seems interesting but some additional changes will be required (like making this feature optional) I will be glad to implement it. 

Class eval was used as it is faster on execution. It takes a little bit longer than define_method to execute first time though.