### PR TITLE
Ruby 3.0: split positional/keyword args

### DIFF
--- a/lib/connection_pool/wrapper.rb
+++ b/lib/connection_pool/wrapper.rb
@@ -32,9 +32,17 @@ class ConnectionPool
 
     # rubocop:disable Style/MethodMissingSuper
     # rubocop:disable Style/MissingRespondToMissing
-    def method_missing(name, *args, &block)
-      with do |connection|
-        connection.send(name, *args, &block)
+    if ::RUBY_VERSION >= "3.0.0"
+      def method_missing(name, *args, **kwargs, &block)
+        with do |connection|
+          connection.send(name, *args, **kwargs, &block)
+        end
+      end
+    else
+      def method_missing(name, *args, &block)
+        with do |connection|
+          connection.send(name, *args, &block)
+        end
       end
     end
     # rubocop:enable Style/MethodMissingSuper

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -8,8 +8,8 @@ class TestConnectionPool < Minitest::Test
       @x = 0
     end
 
-    def do_something
-      @x += 1
+    def do_something(*_args, increment: 1)
+      @x += increment
       sleep SLEEP_TIME
       @x
     end
@@ -332,6 +332,7 @@ class TestConnectionPool < Minitest::Test
     assert_equal 2, pool.do_something
     assert_equal 5, pool.do_something_with_block { 3 }
     assert_equal 6, pool.with { |net| net.fast }
+    assert_equal 8, pool.do_something(increment: 2)
   end
 
   def test_passthru_respond_to


### PR DESCRIPTION
The current version of the gem converts keyword args to a hash arg in Ruby 3.0. I changed the tests to cause a warning in Ruby 2.7 and failure in Ruby 3.0 without the fix.

The proposed fix in wrapper.rb is backwards compatible with 2.2.0 (minimum version from the gemspec). 

Alternately, maybe cut a new major version that requires Ruby 2.7+?

Let me know what you think.