### PR TITLE
Fix argument forwarding in Ruby 2.7

### DIFF
--- a/lib/connection_pool/wrapper.rb
+++ b/lib/connection_pool/wrapper.rb
@@ -32,10 +32,16 @@ class ConnectionPool
 
     # rubocop:disable Style/MethodMissingSuper
     # rubocop:disable Style/MissingRespondToMissing
-    if ::RUBY_VERSION >= "2.7.0"
+    if ::RUBY_VERSION >= "3.0.0"
       def method_missing(name, *args, **kwargs, &block)
         with do |connection|
           connection.send(name, *args, **kwargs, &block)
+        end
+      end
+    elsif ::RUBY_VERSION >= "2.7.0"
+      ruby2_keywords def method_missing(name, *args, &block)
+        with do |connection|
+          connection.send(name, *args, &block)
         end
       end
     else

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -14,6 +14,12 @@ class TestConnectionPool < Minitest::Test
       @x
     end
 
+    def do_something_with_positional_hash(options)
+      @x += options[:increment] || 1
+      sleep SLEEP_TIME
+      @x
+    end
+
     def fast
       @x += 1
     end
@@ -333,6 +339,7 @@ class TestConnectionPool < Minitest::Test
     assert_equal 5, pool.do_something_with_block { 3 }
     assert_equal 6, pool.with { |net| net.fast }
     assert_equal 8, pool.do_something(increment: 2)
+    assert_equal 10, pool.do_something_with_positional_hash({ increment: 2, symbol_key: 3, "string_key" => 4 })
   end
 
   def test_passthru_respond_to


### PR DESCRIPTION
Fixes https://github.com/mperham/connection_pool/issues/148.

In Ruby 2.7 keyword arguments are not yet separated from positional ones. `**kwargs` was seemingly introduced here to suppress warnings, but for accuracy we need to remove `**kwargs` and just add `ruby2_keywords`.