### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -1,5 +1,5 @@
 require "timeout"
-require "connection_pool/version"
+require_relative "connection_pool/version"
 
 class ConnectionPool
   class Error < ::RuntimeError; end
@@ -122,5 +122,5 @@ class ConnectionPool
   end
 end
 
-require "connection_pool/timed_stack"
-require "connection_pool/wrapper"
+require_relative "connection_pool/timed_stack"
+require_relative "connection_pool/wrapper"


### PR DESCRIPTION
Since it's faster and doesn't need to mess with the `$LOAD_PATH`. This is how it was historically done, but it was changed at https://github.com/mperham/connection_pool/commit/dd5dac56607a146aa29ec4ef557c42726541a2fa.

Since changing that seems unrelated to that change, I'd like to go back to `require_relative` if possible.

This is particularly helpful for me as a maintainer of `bundler`, because bundler includes a vendored copy of this library, and we really don't want to mess with the `$LOAD_PATH` at the time we require it. Including this change allows us to vendor the library completely unmodified.