### PR TITLE
Use explicit namespaces for `Mutex` and `ConditionVariable`

### DIFF
--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -29,8 +29,8 @@ class ConnectionPool::TimedStack
     @created = 0
     @que = []
     @max = size
-    @mutex = Mutex.new
-    @resource = ConditionVariable.new
+    @mutex = Thread::Mutex.new
+    @resource = Thread::ConditionVariable.new
     @shutdown_block = nil
   end
 


### PR DESCRIPTION
This upstreams this PR to the rubygems repository: https://github.com/rubygems/rubygems/pull/4709.

Using the explicit `Thread` namespace is the future-proof way of accessing these constants.