### PR TITLE
Drop support for Ruby 2.2

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,10 @@
 # connection_pool Changelog
 
+HEAD
+------
+
+* Drop support for Ruby 2.2 [#154]
+
 2.2.5
 ------
 

--- a/connection_pool.gemspec
+++ b/connection_pool.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler"
   s.add_development_dependency "minitest", ">= 5.0.0"
   s.add_development_dependency "rake"
-  s.required_ruby_version = ">= 2.2.0"
+  s.required_ruby_version = ">= 2.3.0"
 end


### PR DESCRIPTION
As per https://github.com/mperham/connection_pool/pull/153#issuecomment-876534647.