### PR TITLE
Mention new timeout-error class in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ end
 
 If all the objects in the connection pool are in use, `with` will block
 until one becomes available.  If no object is available within `:timeout` seconds,
-`with` will raise a `Timeout::Error`.
+`with` will raise a `ConnectionPool::TimeoutError` (a subclass of `Timeout::Error`).
 
 You can also use `ConnectionPool#then` to support _both_ a
 connection pool and a raw client (requires Ruby 2.5+).


### PR DESCRIPTION
This wasn't updated in https://github.com/mperham/connection_pool/pull/131. I'm not sure if that's intentional or not.