### PR TITLE
Use prerelease aware version comparison

### DIFF
--- a/lib/connection_pool/wrapper.rb
+++ b/lib/connection_pool/wrapper.rb
@@ -32,13 +32,13 @@ class ConnectionPool
 
     # rubocop:disable Style/MethodMissingSuper
     # rubocop:disable Style/MissingRespondToMissing
-    if ::RUBY_VERSION >= "3.0.0"
+    if ::Gem.ruby_version >= ::Gem::Version.new("3.0.0")
       def method_missing(name, *args, **kwargs, &block)
         with do |connection|
           connection.send(name, *args, **kwargs, &block)
         end
       end
-    elsif ::RUBY_VERSION >= "2.7.0"
+    elsif ::Gem.ruby_version >= ::Gem::Version.new("2.7.0")
       ruby2_keywords def method_missing(name, *args, &block)
         with do |connection|
           connection.send(name, *args, &block)


### PR DESCRIPTION
The problem is:

```
irb(main):001:0> "2.7.0.preview1" >= "2.7.0"
=> true
irb(main):002:0> Gem::Version.new("2.7.0.preview1") >= Gem::Version.new("2.7.0")
=> false
```

This is very minor, and will only solve actual issues when using old prereleases of ruby, which is not great anyways (users should upgrade). But I guess it sets a standard in the code, so that if further checks like this are added in the future, they are done like this, in a way that respects prereleases.