### PR TITLE
Use object introspection rather then unreliable version checks.

### DIFF
--- a/lib/connection_pool/wrapper.rb
+++ b/lib/connection_pool/wrapper.rb
@@ -38,7 +38,7 @@ class ConnectionPool
           connection.send(name, *args, **kwargs, &block)
         end
       end
-    elsif ::RUBY_VERSION >= "2.7.0"
+    elsif defined?(:ruby2_keywords)
       ruby2_keywords def method_missing(name, *args, &block)
         with do |connection|
           connection.send(name, *args, &block)


### PR DESCRIPTION
This is intended to be fix to #5119 as well as #5093.

However:

1. I have not tested it at all (except checking that `defined?(:ruby2_keywords)` works.
2. There must be probably even better way to detect the kwargs, so even the Ruby 3.0+ version check could be removed, but I don't really know how to do that :/