### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.4", "2.5", "2.6", "2.7", "3.0", "jruby"]
+        ruby: ["2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "jruby"]
         experimental: [false]
         include:
         - ruby: "truffleruby"


### PR DESCRIPTION
Now that Ruby 3.1 is released it should be added to the CI matrix.