### PR TITLE
Update readme: non critical -> non-critical

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ end
 
 This will only modify the resource-get timeout for this particular
 invocation.
-This is useful if you want to fail-fast on certain non critical
+This is useful if you want to fail-fast on certain non-critical
 sections when a resource is not available, or conversely if you are comfortable blocking longer on a particular resource.
 This is not implemented in the `ConnectionPool::Wrapper` class.
 


### PR DESCRIPTION
* I see non-critical and noncritical, but no `non critical`
* ref: https://en.wiktionary.org/wiki/non-critical

minor concern, pls ignore if you find it trival