### PR TITLE
Automatically drop all connections after fork

### DIFF
--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -549,6 +549,7 @@ class TestConnectionPool < Minitest::Test
   end
 
   def test_after_fork_callback
+    skip("MRI feature") unless Process.respond_to?(:fork)
     GC.start # cleanup instances created by other tests
 
     pool = ConnectionPool.new(size: 2) { NetworkConnection.new }
@@ -559,6 +560,7 @@ class TestConnectionPool < Minitest::Test
   end
 
   def test_after_fork_callback_checkin
+    skip("MRI feature") unless Process.respond_to?(:fork)
     GC.start # cleanup instances created by other tests
 
     pool = ConnectionPool.new(size: 2) { NetworkConnection.new }

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -547,4 +547,40 @@ class TestConnectionPool < Minitest::Test
       assert_equal(1, pool.available)
     end
   end
+
+  def test_after_fork_callback
+    GC.start # cleanup instances created by other tests
+
+    pool = ConnectionPool.new(size: 2) { NetworkConnection.new }
+    prefork_connection = pool.with { |c| c }
+    assert_equal(prefork_connection, pool.with { |c| c })
+    ConnectionPool.after_fork
+    refute_equal(prefork_connection, pool.with { |c| c })
+  end
+
+  def test_after_fork_callback_checkin
+    GC.start # cleanup instances created by other tests
+
+    pool = ConnectionPool.new(size: 2) { NetworkConnection.new }
+    prefork_connection = pool.checkout
+    assert_equal(prefork_connection, pool.checkout)
+    ConnectionPool.after_fork
+    refute_equal(prefork_connection, pool.checkout)
+  end
+
+  def test_automatic_after_fork_callback
+    skip("MRI 3.1 feature") unless Process.respond_to?(:_fork)
+    GC.start # cleanup instances created by other tests
+
+    pool = ConnectionPool.new(size: 2) { NetworkConnection.new }
+    prefork_connection = pool.with { |c| c }
+    assert_equal(prefork_connection, pool.with { |c| c })
+    pid = fork do
+      refute_equal(prefork_connection, pool.with { |c| c })
+      exit!(0)
+    end
+    assert_equal(prefork_connection, pool.with { |c| c })
+    _, status = Process.waitpid2(pid)
+    assert_predicate(status, :success?)
+  end
 end


### PR DESCRIPTION
Fix: https://github.com/mperham/connection_pool/issues/165

Using connections inherited from a parent process can have very nasty consequences and it's pretty much never desired.

This patch use the `Process._fork` API added in Ruby 3.1 to automatically detect when a fork is happening, and when it does, drop all existing connections.

### Notes

#### Performance
`ObjectSpace.each_object` is very slow for large applications:

```ruby
[1] pry(main)> Benchmark.realtime { ObjectSpace.each_object(ConnectionPool) { |c| c }.size }
=> 0.06875399989075959
[2] pry(main)> Rails.application.eager_load!
=> nil
[3] pry(main)> Benchmark.realtime { ObjectSpace.each_object(ConnectionPool) { |c| c }.size }
=> 0.14990400010719895
[4] pry(main)> Benchmark.realtime { fork { exit! }}
=> 0.004583500092849135
```

So I'd really recommend to keep track of instance with `ObjectSpace::WeakMap`. I'll push a commit in another branch and let you decide.

#### Connection closing

Since `ConnectionPool` doesn't know how to close a connection, this feature simply drop the references, and assume the Ruby GC will do the right thing.

