### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/connection_pool.gemspec
+++ b/connection_pool.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", ">= 5.0.0"
   s.add_development_dependency "rake"
   s.required_ruby_version = ">= 2.5.0"
+
+  s.metadata = { "rubygems_mfa_required" => "true" }
 end


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/