### PR TITLE
Set "changelog_uri" in gemspec to point to Changes.md

### DIFF
--- a/connection_pool.gemspec
+++ b/connection_pool.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.required_ruby_version = ">= 2.5.0"
 
-  s.metadata = { "rubygems_mfa_required" => "true" }
+  s.metadata = { "changelog_uri" => "https://github.com/mperham/connection_pool/blob/main/Changes.md", "rubygems_mfa_required" => "true" }
 end


### PR DESCRIPTION
## What

Add `changelog_uri` to the gem metadata.

## Why

Changelog URLs have been valid [metadata](https://guides.rubygems.org/specification-reference/#metadata) since 2017 on RubyGems.org. Setting `changelog_uri` will add a "Changelog" link to the Rubygems page for connection_pool https://rubygems.org/gems/connection_pool/