### PR TITLE
Ability to optionally drop all connections after fork

### DIFF
--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -559,6 +559,18 @@ class TestConnectionPool < Minitest::Test
     refute_equal(prefork_connection, pool.with { |c| c })
   end
 
+  def test_after_fork_callback_being_skipped
+    skip("MRI feature") unless Process.respond_to?(:fork)
+    GC.start # cleanup instances created by other tests
+
+    pool = ConnectionPool.new(size: 2, auto_reload_after_fork: false) { NetworkConnection.new }
+    prefork_connection = pool.with { |c| c }
+    assert_equal(prefork_connection, pool.with { |c| c })
+    ConnectionPool.after_fork
+    assert_equal(prefork_connection, pool.with { |c| c })
+  end
+
+
   def test_after_fork_callback_checkin
     skip("MRI feature") unless Process.respond_to?(:fork)
     GC.start # cleanup instances created by other tests


### PR DESCRIPTION
There was a recent feature to automatically drop all connections after fork. This is quite nice and makes sense.

However, for some rails app that usually don't follow the fork model (like w/ unicorn/puma), and additionally have some logic to fork processes to perform internal business logic that doesn't rely or use `ConnectionPool`, the application can observe Redis connection issues or resets. These forks can happen during application run time. Like ours.

In such a case, it'd be nice to not automatically drop all the connections, since the underlying process isn't working with Redis/ConnectionPool, and as a sideeffect the pool in the primary process is impacted.

This PR proposes a new attribute `auto_reload_after_fork` as a config option. By default it is `true`. However, application users can turn it to `false` and not opt in for the feature to auto drop connections after fork.

This could be quite useful for us

Closes: https://github.com/mperham/connection_pool/issues/175