### PR TITLE
this should be left up to the client library

### DIFF
--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -57,11 +57,7 @@ class ConnectionPool
         # All we need to do is to ensure the main thread doesn't have a
         # checked out connection
         pool.checkin(force: true)
-        pool.reload do |connection|
-          # Unfortunately we don't know what method to call to close the connection,
-          # so we try the most common one.
-          connection.close if connection.respond_to?(:close)
-        end
+        pool.reload
       end
       nil
     end


### PR DESCRIPTION
Resolving #180. I don't think this is a safe assumption to make about client libraries, since `close` doesn't necessarily only affect process-specific state. Sometimes the fork parent may intend to use that connection again and the forked child ends up breaking it (e.g. Dalli clients and Puma's fork_worker), so the parent still has the connection in the pool but its remote state is invalid. If the parent forks twice, it's also reliant on the client to not just implement `close`, but to do it in idempotent fashion so the second child doesn't blow up trying to close an already-closed connection. The state of a connection object post-fork seems best left to the connection library itself; the pool does enough by just removing whatever connections there are from the pool so the forked child cannot check them out.