### PR TITLE
Add reap functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ cp.with { |conn| conn.get('some-count') }
 
 Like `shutdown`, this will block until all connections are checked in and closed.
 
+## Reap
+
+You can reap idle connections in the ConnectionPool instance to close connections that were created but have not been used for a certain amount of time. This can be useful to run periodically in a separate thread especially if keeping the connection open is resource intensive.
+
+You can specify how many seconds the connections have to be idle for them to be reaped.
+Defaults to 60 seconds.
+
+```ruby
+cp = ConnectionPool.new { Redis.new }
+cp.reap(300) { |conn| conn.close } # Reaps connections that have been idle for 300 seconds (5 minutes).
+```
+
 ## Current State
 
 There are several methods that return information about a pool.
@@ -109,11 +121,15 @@ There are several methods that return information about a pool.
 cp = ConnectionPool.new(size: 10) { Redis.new }
 cp.size # => 10
 cp.available # => 10
+cp.idle # => 0
 
 cp.with do |conn|
   cp.size # => 10
   cp.available # => 9
+  cp.idle # => 0
 end
+
+cp.idle # => 1
 ```
 
 Notes

--- a/README.md
+++ b/README.md
@@ -113,6 +113,22 @@ cp = ConnectionPool.new { Redis.new }
 cp.reap(300) { |conn| conn.close } # Reaps connections that have been idle for 300 seconds (5 minutes).
 ```
 
+### Reaper Thread
+
+You can start your own reaper thread to reap idle connections in the ConnectionPool instance on a regular interval.
+
+```ruby
+cp = ConnectionPool.new { Redis.new }
+
+# Start a reaper thread to reap connections that have been idle for 300 seconds (5 minutes).
+Thread.new do
+  loop do
+    cp.reap(300) { |conn| conn.close }
+    sleep 300
+  end
+end
+```
+
 ## Current State
 
 There are several methods that return information about a pool.

--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -161,8 +161,8 @@ class ConnectionPool
   end
 
   ## Reaps idle connections that have been idle for over +idle_seconds+.
-  # +idle_seconds+ defaults to 0, i.e. reap all idle connections.
-  def reap(idle_seconds = 0, &block)
+  # +idle_seconds+ defaults to 60.
+  def reap(idle_seconds = 60, &block)
     @available.reap(idle_seconds, &block)
   end
 

--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -160,6 +160,12 @@ class ConnectionPool
     @available.shutdown(reload: true, &block)
   end
 
+  ## Reaps idle connections that have been idle for over +idle_seconds+.
+  # +idle_seconds+ defaults to 0, i.e. reap all idle connections.
+  def reap(idle_seconds = 0, &block)
+    @available.reap(idle_seconds, &block)
+  end
+
   # Size of this connection pool
   attr_reader :size
   # Automatically drop all connections after fork
@@ -168,6 +174,11 @@ class ConnectionPool
   # Number of pool entries available for checkout at this instant.
   def available
     @available.length
+  end
+
+  # Number of pool entries created and idle in the pool.
+  def idle
+    @available.idle
   end
 end
 

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -31,7 +31,7 @@ class TestConnectionPool < Minitest::Test
     end
 
     def respond_to?(method_id, *args)
-      method_id == :do_magic || super(method_id, *args)
+      method_id == :do_magic || super
     end
   end
 
@@ -465,6 +465,74 @@ class TestConnectionPool < Minitest::Test
     kill_threads(threads)
 
     assert_equal [["shutdown"]] * 3, recorders.map { |r| r.calls }
+  end
+
+  def test_reap_removes_idle_connections
+    recorders = []
+    pool = ConnectionPool.new(size: 1) do
+      Recorder.new.tap { |r| recorders << r }
+    end
+
+    pool.with { |conn| conn }
+
+    assert_equal 1, pool.idle
+
+    pool.reap { |recorder| recorder.do_work("reap") }
+
+    assert_equal 0, pool.idle
+    assert_equal [["reap"]], recorders.map(&:calls)
+  end
+
+  def test_reap_removes_all_idle_connections
+    recorders = []
+    pool = ConnectionPool.new(size: 3) do
+      Recorder.new.tap { |r| recorders << r }
+    end
+    threads = use_pool(pool, 3)
+    kill_threads(threads)
+
+    assert_equal 3, pool.idle
+
+    pool.reap { |recorder| recorder.do_work("reap") }
+
+    assert_equal 0, pool.idle
+    assert_equal [["reap"]] * 3, recorders.map(&:calls)
+  end
+
+  def test_reap_does_not_remove_connections_if_outside_idle_time
+    pool = ConnectionPool.new(size: 1) { Object.new }
+
+    pool.with { |conn| conn }
+
+    pool.reap(1000) { |conn| flunk "should not reap active connection" }
+  end
+
+  def test_idle_returns_number_of_idle_connections
+    pool = ConnectionPool.new(size: 1) { Object.new }
+
+    assert_equal 0, pool.idle
+
+    pool.checkout
+
+    assert_equal 0, pool.idle
+
+    pool.checkin
+
+    assert_equal 1, pool.idle
+  end
+
+  def test_idle_with_multiple_connections
+    pool = ConnectionPool.new(size: 3) { Object.new }
+
+    assert_equal 0, pool.idle
+
+    threads = use_pool(pool, 3)
+
+    assert_equal 0, pool.idle
+
+    kill_threads(threads)
+
+    assert_equal 3, pool.idle
   end
 
   def test_wrapper_wrapped_pool

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -477,7 +477,7 @@ class TestConnectionPool < Minitest::Test
 
     assert_equal 1, pool.idle
 
-    pool.reap { |recorder| recorder.do_work("reap") }
+    pool.reap(0) { |recorder| recorder.do_work("reap") }
 
     assert_equal 0, pool.idle
     assert_equal [["reap"]], recorders.map(&:calls)
@@ -493,7 +493,7 @@ class TestConnectionPool < Minitest::Test
 
     assert_equal 3, pool.idle
 
-    pool.reap { |recorder| recorder.do_work("reap") }
+    pool.reap(0) { |recorder| recorder.do_work("reap") }
 
     assert_equal 0, pool.idle
     assert_equal [["reap"]] * 3, recorders.map(&:calls)


### PR DESCRIPTION
There have been several discussions/attempts at adding a idle connection reaping functionality to this gem: https://github.com/mperham/connection_pool/issues/125 https://github.com/mperham/connection_pool/pull/127 https://github.com/mperham/connection_pool/pull/126

I and many others would find value in adding this functionality however I am in agreement with the previous discussions that the key to adding this `reap` functionality is to add it in a way that keeps the simplicity of this gem.

In order to accomplish this, I've added two new public methods to `ConnectionPool` (as well as matching methods for `TimedStack`):
1. `#idle` - Returns how many connections that are created and available in the pool. This is different than `available` because `available` includes connections that haven't been created yet.
2. `#reap(idle_seconds = 0, &block)` - Removes connections that have been idle for longer than `idle_seconds` and yields each connection to the block passed to the method in order to close/clean up the connection. By default, `idle_seconds` is 0, which means `#reap` will remove all connections that are on the stack.

In order to implement the `#reap` method in connection pool, I've changed how the `TimedStack` queue stores connections in the queue to also include the current time when pushed back onto the stack.