### PR TITLE
Fix reaper exhausting the queue

### DIFF
--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -178,6 +178,8 @@ class ConnectionPool::TimedStack
     while idle_connections?(idle_seconds, reap_start_time)
       conn, _last_checked_out = @que.shift
       reap_block.call(conn)
+      # Decrement created unless this is a no create stack
+      @created -= 1 unless @max == 0
     end
   end
 

--- a/test/test_connection_pool_timed_stack.rb
+++ b/test/test_connection_pool_timed_stack.rb
@@ -175,6 +175,18 @@ class TestConnectionPoolTimedStack < Minitest::Test
     assert_empty @stack
   end
 
+  def test_reap_full_stack
+    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack.push stack.pop
+
+    stack.reap(0) do |object|
+      nil
+    end
+
+    # Can still pop from the stack after reaping all connections
+    refute_nil stack.pop
+  end
+
   def test_reap_large_idle_seconds
     @stack.push Object.new
 
@@ -250,7 +262,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
     end
 
     assert_equal [conn1, conn2], called
-    assert_empty stack
+    assert_equal 0, stack.idle
   end
 
   def test_reap_with_multiple_connections_and_idle_seconds_outside_range


### PR DESCRIPTION
After max queue size connections have been reaped, no new connections are allowed to be created.

I'm am not sure how intended the 0 pool size behavior is. The tests make a lot of use of it but it seems counter to normal use.