### PR TITLE
Avoid extra mutex contention

### DIFF
--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -178,6 +178,8 @@ class ConnectionPool::TimedStack
     while idle_connections?(idle_seconds, reap_start_time)
       conn, _last_checked_out = @que.shift
       reap_block.call(conn)
+      # Decrement created unless this is a no create stack
+      @created -= 1 unless @max == 0
     end
   end
 

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -535,6 +535,16 @@ class TestConnectionPool < Minitest::Test
     assert_equal 3, pool.idle
   end
 
+  def test_reap_raises_error_after_shutting_down
+    pool = ConnectionPool.new(size: 1) { true }
+
+    pool.shutdown {}
+
+    assert_raises ConnectionPool::PoolShuttingDownError do
+      pool.reap(0) {}
+    end
+  end
+
   def test_wrapper_wrapped_pool
     wrapper = ConnectionPool::Wrapper.new { NetworkConnection.new }
     assert_equal ConnectionPool, wrapper.wrapped_pool.class

--- a/test/test_connection_pool_timed_stack.rb
+++ b/test/test_connection_pool_timed_stack.rb
@@ -175,6 +175,18 @@ class TestConnectionPoolTimedStack < Minitest::Test
     assert_empty @stack
   end
 
+  def test_reap_full_stack
+    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack.push stack.pop
+
+    stack.reap(0) do |object|
+      nil
+    end
+
+    # Can still pop from the stack after reaping all connections
+    refute_nil stack.pop
+  end
+
   def test_reap_large_idle_seconds
     @stack.push Object.new
 
@@ -250,7 +262,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
     end
 
     assert_equal [conn1, conn2], called
-    assert_empty stack
+    assert_equal 0, stack.idle
   end
 
   def test_reap_with_multiple_connections_and_idle_seconds_outside_range


### PR DESCRIPTION
NOTE: This includes the commit from #188 so I didn't have to deal with wonky rebasing.

This limits the mutex lock to interactions with the stack that are small, fast, and atomic. Moving the connection close code outside the mutex as it doesn't impact the pool.

Sidenote: Thinking about releasing the reap update, it probably needs to be a major version bump as it breaks things for anyone that has used the defined extension points and interacts with `@que`. It is probably possible this could be modified to only introduce a breaking change if `reap` is used.