### PR TITLE
Make automatically fixable standard issues fail CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
         ruby-version: ${{matrix.ruby}}
         bundler-cache: true
 
+    - name: Run standardrb
+      run: bundle exec standardrb --no-fix
+
     - name: Run tests
       timeout-minutes: 5
-      run: ${{matrix.env}} bundle exec rake
+      run: ${{matrix.env}} bundle exec rake test


### PR DESCRIPTION
While default autofix is handy, the configuration makes it so that auto-fixable issues don't trigger a CI failure. I ran into this on some other projects.