### PR TITLE
Track checked out created connections across reloads

### DIFF
--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -41,7 +41,7 @@ class ConnectionPool::TimedStack
   def push(obj, options = {})
     @mutex.synchronize do
       if @shutdown_block
-        decrement_created
+        @created -= 1 unless @created == 0
         @shutdown_block.call(obj)
       else
         store_connection obj, options
@@ -170,7 +170,7 @@ class ConnectionPool::TimedStack
   def shutdown_connections(options = nil)
     while connection_stored?(options)
       conn = fetch_connection(options)
-      decrement_created
+      @created -= 1 unless @created == 0
       @shutdown_block.call(conn)
     end
   end
@@ -184,7 +184,7 @@ class ConnectionPool::TimedStack
   def reserve_idle_connection(idle_seconds)
     return unless idle_connections?(idle_seconds)
 
-    decrement_created
+    @created -= 1 unless @created == 0
 
     @que.shift.first
   end
@@ -219,14 +219,5 @@ class ConnectionPool::TimedStack
       @created += 1
       object
     end
-  end
-
-  ##
-  # This is an extension point for TimedStack and is called with a mutex.
-  #
-  # Decrement created unless no connections have been created.
-  # This is safe for no-create stacks since @created will always be 0.
-  def decrement_created
-    @created -= 1 unless @created == 0
   end
 end

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -407,6 +407,17 @@ class TestConnectionPool < Minitest::Test
     assert_equal [["shutdown"]] * 3, recorders.map { |r| r.calls }
   end
 
+  def test_checkout_after_reload_cannot_create_new_connections_beyond_size
+    pool = ConnectionPool.new(size: 1) { Object.new }
+    threads = use_pool pool, 1
+    pool.reload {}
+    assert_raises ConnectionPool::TimeoutError do
+      pool.checkout(timeout: 0)
+    end
+  ensure
+    kill_threads(threads) if threads
+  end
+
   def test_raises_error_after_shutting_down
     pool = ConnectionPool.new(size: 1) { true }
 


### PR DESCRIPTION
There appears to be a small bug around `ConnectionPool#reload` where it is possible to create more connections than the size of the pool if you run `reload` while a connection is checked out.

See the test cases defined in https://github.com/mperham/connection_pool/pull/192/commits/4f4e5f6b28eef2ac3d07827f86bbbae0a0570c96

These test cases all fail on the master branch. This is due to how `@created` instance variable in `ConnectionPool::TimedStack` is decremented, where currently it is set to 0 on `#shutdown(reload: true)` even if no connections were "shutdown" on the reload.