### PR TITLE
feat: Drop support for EOLd Rubies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "jruby"]
+        ruby: ["3.2", "3.3", "3.4", "jruby"]
         experimental: [false]
         include:
         - ruby: "truffleruby"

--- a/connection_pool.gemspec
+++ b/connection_pool.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler"
   s.add_development_dependency "minitest", ">= 5.0.0"
   s.add_development_dependency "rake"
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 3.2"
 
   s.metadata = {"changelog_uri" => "https://github.com/mperham/connection_pool/blob/main/Changes.md", "rubygems_mfa_required" => "true"}
 end

--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -5,7 +5,7 @@
 #
 # Examples:
 #
-#    ts = TimedStack.new(1) { MyConnection.new }
+#    ts = TimedStack.new(size: 1) { MyConnection.new }
 #
 #    # fetch a connection
 #    conn = ts.pop
@@ -22,7 +22,7 @@ class ConnectionPool::TimedStack
   ##
   # Creates a new pool with +size+ connections that are created from the given
   # +block+.
-  def initialize(size = 0, &block)
+  def initialize(size: 0, &block)
     @create_block = block
     @created = 0
     @que = []
@@ -35,13 +35,13 @@ class ConnectionPool::TimedStack
   ##
   # Returns +obj+ to the stack. +options+ is ignored in TimedStack but may be
   # used by subclasses that extend TimedStack.
-  def push(obj, options = {})
+  def push(obj, **options)
     @mutex.synchronize do
       if @shutdown_block
         @created -= 1 unless @created == 0
         @shutdown_block.call(obj)
       else
-        store_connection obj, options
+        store_connection obj, **options
       end
 
       @resource.broadcast
@@ -57,19 +57,16 @@ class ConnectionPool::TimedStack
   # +:timeout+ is the only checked entry in +options+ and is preferred over
   # the +timeout+ argument (which will be removed in a future release). Other
   # options may be used by subclasses that extend TimedStack.
-  def pop(timeout = 0.5, options = {})
-    options, timeout = timeout, 0.5 if Hash === timeout
-    timeout = options.fetch :timeout, timeout
-
+  def pop(timeout: 0.5, **options)
     deadline = current_time + timeout
     @mutex.synchronize do
       loop do
         raise ConnectionPool::PoolShuttingDownError if @shutdown_block
-        if (conn = try_fetch_connection(options))
+        if (conn = try_fetch_connection(**options))
           return conn
         end
 
-        connection = try_create(options)
+        connection = try_create(**options)
         return connection if connection
 
         to_wait = deadline - current_time
@@ -98,7 +95,7 @@ class ConnectionPool::TimedStack
 
   ##
   # Reaps connections that were checked in more than +idle_seconds+ ago.
-  def reap(idle_seconds, &block)
+  def reap(idle_seconds:, &block)
     raise ArgumentError, "reap must receive a block" unless block
     raise ArgumentError, "idle_seconds must be a number" unless idle_seconds.is_a?(Numeric)
     raise ConnectionPool::PoolShuttingDownError if @shutdown_block
@@ -152,15 +149,15 @@ class ConnectionPool::TimedStack
   # This method must returns a connection from the stack if one exists. Allows
   # subclasses with expensive match/search algorithms to avoid double-handling
   # their stack.
-  def try_fetch_connection(options = nil)
-    connection_stored?(options) && fetch_connection(options)
+  def try_fetch_connection(**options)
+    connection_stored?(**options) && fetch_connection(**options)
   end
 
   ##
   # This is an extension point for TimedStack and is called with a mutex.
   #
   # This method must returns true if a connection is available on the stack.
-  def connection_stored?(options = nil)
+  def connection_stored?(**options)
     !@que.empty?
   end
 
@@ -168,7 +165,7 @@ class ConnectionPool::TimedStack
   # This is an extension point for TimedStack and is called with a mutex.
   #
   # This method must return a connection from the stack.
-  def fetch_connection(options = nil)
+  def fetch_connection(**options)
     @que.pop&.first
   end
 
@@ -176,8 +173,8 @@ class ConnectionPool::TimedStack
   # This is an extension point for TimedStack and is called with a mutex.
   #
   # This method must shut down all connections on the stack.
-  def shutdown_connections(options = nil)
-    while (conn = try_fetch_connection(options))
+  def shutdown_connections(**options)
+    while (conn = try_fetch_connection(**options))
       @created -= 1 unless @created == 0
       @shutdown_block.call(conn)
     end
@@ -208,7 +205,7 @@ class ConnectionPool::TimedStack
   # This is an extension point for TimedStack and is called with a mutex.
   #
   # This method must return +obj+ to the stack.
-  def store_connection(obj, options = nil)
+  def store_connection(obj, **options)
     @que.push [obj, current_time]
   end
 
@@ -217,7 +214,7 @@ class ConnectionPool::TimedStack
   #
   # This method must create a connection if and only if the total number of
   # connections allowed has not been met.
-  def try_create(options = nil)
+  def try_create(**options)
     unless @created == @max
       object = @create_block.call
       @created += 1

--- a/lib/connection_pool/wrapper.rb
+++ b/lib/connection_pool/wrapper.rb
@@ -2,8 +2,8 @@ class ConnectionPool
   class Wrapper < ::BasicObject
     METHODS = [:with, :pool_shutdown, :wrapped_pool]
 
-    def initialize(options = {}, &block)
-      @pool = options.fetch(:pool) { ::ConnectionPool.new(options, &block) }
+    def initialize(**options, &block)
+      @pool = options.fetch(:pool) { ::ConnectionPool.new(**options, &block) }
     end
 
     def wrapped_pool
@@ -30,27 +30,10 @@ class ConnectionPool
       METHODS.include?(id) || with { |c| c.respond_to?(id, *args) }
     end
 
-    # rubocop:disable Style/MissingRespondToMissing
-    if ::RUBY_VERSION >= "3.0.0"
-      def method_missing(name, *args, **kwargs, &block)
-        with do |connection|
-          connection.send(name, *args, **kwargs, &block)
-        end
-      end
-    elsif ::RUBY_VERSION >= "2.7.0"
-      ruby2_keywords def method_missing(name, *args, &block)
-        with do |connection|
-          connection.send(name, *args, &block)
-        end
-      end
-    else
-      def method_missing(name, *args, &block)
-        with do |connection|
-          connection.send(name, *args, &block)
-        end
+    def method_missing(name, *args, **kwargs, &block)
+      with do |connection|
+        connection.send(name, *args, **kwargs, &block)
       end
     end
-    # rubocop:enable Style/MethodMissingSuper
-    # rubocop:enable Style/MissingRespondToMissing
   end
 end

--- a/test/test_connection_pool_timed_stack.rb
+++ b/test/test_connection_pool_timed_stack.rb
@@ -6,7 +6,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_empty_eh
-    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 1) { Object.new }
 
     refute_empty stack
 
@@ -20,7 +20,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_length
-    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 1) { Object.new }
 
     assert_equal 1, stack.length
 
@@ -46,7 +46,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_length_after_shutdown_reload_with_checked_out_conn
-    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 1) { Object.new }
     conn = stack.pop
     stack.shutdown(reload: true) {}
     assert_equal 0, stack.length
@@ -55,7 +55,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_idle
-    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 1) { Object.new }
 
     assert_equal 0, stack.idle
 
@@ -69,7 +69,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_object_creation_fails
-    stack = ConnectionPool::TimedStack.new(2) { raise "failure" }
+    stack = ConnectionPool::TimedStack.new(size: 2) { raise "failure" }
 
     begin
       stack.pop
@@ -102,12 +102,12 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_pop_empty_2_0_compatibility
-    e = assert_raises(Timeout::Error) { @stack.pop 0 }
+    e = assert_raises(ConnectionPool::TimeoutError) { @stack.pop(timeout: 0) }
     assert_equal "Waited 0 sec, 0/0 available", e.message
   end
 
   def test_pop_full
-    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 1) { Object.new }
 
     popped = stack.pop
 
@@ -116,7 +116,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_pop_full_with_extra_conn_pushed
-    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 1) { Object.new }
     popped = stack.pop
 
     stack.push(Object.new)
@@ -128,7 +128,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
 
     assert_equal 1, stack.length
     stack.pop
-    assert_raises(ConnectionPool::TimeoutError) { stack.pop(0) }
+    assert_raises(ConnectionPool::TimeoutError) { stack.pop(timeout: 0) }
   end
 
   def test_pop_wait
@@ -154,7 +154,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_pop_shutdown_reload
-    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 1) { Object.new }
     object = stack.pop
     stack.push(object)
 
@@ -164,16 +164,16 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_pop_raises_error_if_shutdown_reload_is_run_and_connection_is_still_in_use
-    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 1) { Object.new }
     stack.pop
     stack.shutdown(reload: true) {}
     assert_raises ConnectionPool::TimeoutError do
-      stack.pop(0)
+      stack.pop(timeout: 0)
     end
   end
 
   def test_push
-    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 1) { Object.new }
 
     conn = stack.pop
 
@@ -247,12 +247,12 @@ class TestConnectionPoolTimedStack < Minitest::Test
     end
 
     assert_raises(closing_error) do
-      @stack.reap(0, &reap_proc)
+      @stack.reap(idle_seconds: 0, &reap_proc)
     end
 
     assert_equal 1, called.size
 
-    @stack.reap(0, &reap_proc)
+    @stack.reap(idle_seconds: 0, &reap_proc)
     assert_equal 3, called.size
   end
 
@@ -261,7 +261,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
 
     called = []
 
-    @stack.reap(0) do |object|
+    @stack.reap(idle_seconds: 0) do |object|
       called << object
     end
 
@@ -270,10 +270,10 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_reap_full_stack
-    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 1) { Object.new }
     stack.push stack.pop
 
-    stack.reap(0) do |object|
+    stack.reap(idle_seconds: 0) do |object|
       nil
     end
 
@@ -286,7 +286,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
 
     called = []
 
-    @stack.reap(100) do |object|
+    @stack.reap(idle_seconds: 100) do |object|
       called << object
     end
 
@@ -296,18 +296,18 @@ class TestConnectionPoolTimedStack < Minitest::Test
 
   def test_reap_no_block
     assert_raises(ArgumentError) do
-      @stack.reap(0)
+      @stack.reap(idle_seconds: 0)
     end
   end
 
   def test_reap_non_numeric_idle_seconds
     assert_raises(ArgumentError) do
-      @stack.reap("0") { |object| object }
+      @stack.reap(idle_seconds: "0") { |object| object }
     end
   end
 
   def test_reap_with_multiple_connections
-    stack = ConnectionPool::TimedStack.new(2) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 2) { Object.new }
     stubbed_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     conn1 = stack.pop
     conn2 = stack.pop
@@ -323,7 +323,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
     called = []
 
     stack.stub :current_time, stubbed_time + 2 do
-      stack.reap(1.5) do |object|
+      stack.reap(idle_seconds: 1.5) do |object|
         called << object
       end
     end
@@ -334,7 +334,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_reap_with_multiple_connections_and_zero_idle_seconds
-    stack = ConnectionPool::TimedStack.new(2) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 2) { Object.new }
     stubbed_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     conn1 = stack.pop
     conn2 = stack.pop
@@ -350,7 +350,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
     called = []
 
     stack.stub :current_time, stubbed_time + 2 do
-      stack.reap(0) do |object|
+      stack.reap(idle_seconds: 0) do |object|
         called << object
       end
     end
@@ -360,7 +360,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_reap_with_multiple_connections_and_idle_seconds_outside_range
-    stack = ConnectionPool::TimedStack.new(2) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 2) { Object.new }
     stubbed_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     conn1 = stack.pop
     conn2 = stack.pop
@@ -376,7 +376,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
     called = []
 
     stack.stub :current_time, stubbed_time + 2 do
-      stack.reap(3) do |object|
+      stack.reap(idle_seconds: 3) do |object|
         called << object
       end
     end
@@ -386,12 +386,12 @@ class TestConnectionPoolTimedStack < Minitest::Test
   end
 
   def test_reap_does_not_loop_continuously
-    stack = ConnectionPool::TimedStack.new(2) { Object.new }
+    stack = ConnectionPool::TimedStack.new(size: 2) { Object.new }
     stack.push(Object.new)
     stack.push(Object.new)
 
     close_attempts = 0
-    stack.reap(0) do |conn|
+    stack.reap(idle_seconds: 0) do |conn|
       if close_attempts >= 2
         flunk "Reap is stuck in a loop"
       end

--- a/test/test_timed_stack_subclassing.rb
+++ b/test/test_timed_stack_subclassing.rb
@@ -9,7 +9,7 @@ class TestTimedStackSubclassing < Minitest::Test
 
   def test_try_fetch_connection
     obj = Object.new
-    stack = @klass.new(1) { obj }
+    stack = @klass.new(size: 1) { obj }
     assert_equal false, stack.send(:try_fetch_connection)
     assert_equal obj, stack.pop
     stack.push obj
@@ -19,7 +19,7 @@ class TestTimedStackSubclassing < Minitest::Test
   def test_override_try_fetch_connection
     obj = Object.new
 
-    stack = @klass.new(1) { obj }
+    stack = @klass.new(size: 1) { obj }
     stack.push stack.pop
 
     connection_stored_called = "cs_called"


### PR DESCRIPTION
This PR drops support for [EOLd rubies](https://endoflife.date/ruby) - Ruby version must be >= 3.2.

Addresses part of #198