### PR TITLE
Add minitest-mock dev dependency

### DIFF
--- a/connection_pool.gemspec
+++ b/connection_pool.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 3.2.0"
   s.add_development_dependency "bundler"
   s.add_development_dependency "maxitest"
+  s.add_development_dependency "minitest-mock"
   s.add_development_dependency "rake"
 
   s.metadata = {

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,6 +4,7 @@ Bundler.require(:default, :test)
 require "minitest/pride"
 require "maxitest/autorun"
 require "maxitest/threads"
+require "minitest/mock"
 # require "maxitest/timeout"
 # Maxitest.timeout = 0.5
 


### PR DESCRIPTION
Minitest 6 extracted 'minitest/mock.rb' to the minitest-mock gem.